### PR TITLE
JAVA-12015: Align module names

### DIFF
--- a/src/main/resources/exceptions-for-tests.yaml
+++ b/src/main/resources/exceptions-for-tests.yaml
@@ -139,7 +139,7 @@ givenAllArticles_whenAnArticleLoads_thenItDoesNotLinkToOldJavaDocs:
 givenTutorialsRepo_whenAllModulesAnalysed_thenFolderNameAndArtifiactIdAndModuleNameMatch:
  - /spring-cloud/spring-cloud-zuul-eureka-integration/bin
  - /guest/slf4j/guide
- - /maven-archetype/src/main/resources/archetype-resources
+ - /maven-modules/maven-archetype/src/main/resources/archetype-resources
 givenAGitHubModuleReadme_whenAnalysingTheReadme_thenLinksToAndFromGithubMatch:
  - https://github.com/eugenp/tutorials/blob/master/README.md
  - https://github.com/eugenp/tutorials/tree/master/README.md


### PR DESCRIPTION
Align module names, folder names and artifact id: the module maven-archetype was moved inside maven-modules and started showing up as misaligned in the build - http://jenkins.baeldung.com/view/site-monitor/view/site-watch/job/sites-monitor/job/site-watch/view/0%20-%20Others/job/blogwath-find-unaligned-modules/16/org$blogwath/testReport/com.baeldung.selenium.common/CommonUITest/givenTutorialsRepo_whenAllModulesAnalysed_thenFolderNameAndArtifiactIdAndModuleNameMatch/