### PR TITLE
Updated exceptions list

### DIFF
--- a/src/main/resources/exceptions-for-tests.yaml
+++ b/src/main/resources/exceptions-for-tests.yaml
@@ -14,6 +14,9 @@ givenAllArticles_whenAnArticleLoads_thenItHasSingleShortcodeAtTheEnd:
   - /cs/
   - /scala/
   - /codota/
+  - /spring-boot-datacassandratest
+  - /java-cassandra-unit
+  - /java-lightrun
 givenAllArticlesAndPages_whenAnalysingImages_thenImagesDoNotPoinToTheDraftsSite:
   - /javafx/
   - /java-sms-twilio/


### PR DESCRIPTION
Added 3 sponsored articles that are not supposed to have bottom shortcode to givenAllArticles_whenAnArticleLoads_thenItHasSingleShortcodeAtTheEnd