### PR TITLE
JAVA-14446: add exceptions to not built modules

### DIFF
--- a/src/main/resources/exceptions-for-tests.yaml
+++ b/src/main/resources/exceptions-for-tests.yaml
@@ -155,12 +155,8 @@ givenTheTutorialsRepository_listAllTheModulesThatAreNotBuildInBothDefautlAndInte
   - /core-java-modules/core-java-16/
   - /core-java-modules/core-java-17/
   - /core-java-modules/core-java-9-new-features/
-  - /ethereum/
   - /guest/
-  - /rule-engines/jess/
-  - /security-modules/
-  - /spring-jinq/
-
+  
 givenAGitHubModuleReadme_whenAnalysingTheReadme_thentheReadmeDoesNotLikTooManyArticles:
   - https://github.com/eugenp/tutorials/tree/master/spring-boot-rest/README.md
   - https://github.com/eugenp/tutorials/tree/master/spring-5-reactive-modules/spring-reactive/README.md

--- a/src/main/resources/exceptions-for-tests.yaml
+++ b/src/main/resources/exceptions-for-tests.yaml
@@ -148,6 +148,18 @@ givenAllArticles_whenAnArticleLoads_thenItIsHasASingleOptinInTheAfterPostContent
 givenAllArticles_whenAnArticleLoads_thenTheArticleHasProperDotsInTitle:
   - /string/
 givenTheTutorialsRepository_listAllTheModulesThatAreNotBuildInBothDefautlAndIntegrationTests:
+  - /core-java-modules/core-java-12/
+  - /core-java-modules/core-java-13/
+  - /core-java-modules/core-java-14/
+  - /core-java-modules/core-java-15/
+  - /core-java-modules/core-java-16/
+  - /core-java-modules/core-java-17/
+  - /core-java-modules/core-java-9-new-features/
+  - /ethereum/
+  - /guest/
+  - /rule-engines/jess/
+  - /security-modules/
+  - /spring-jinq/
 
 givenAGitHubModuleReadme_whenAnalysingTheReadme_thentheReadmeDoesNotLikTooManyArticles:
   - https://github.com/eugenp/tutorials/tree/master/spring-boot-rest/README.md


### PR DESCRIPTION
These modules are not being built in both default and integration tests for reasons listed in the main pom.