### PR TITLE
JAVA-13330 filter out @Generated marked classes

### DIFF
--- a/src/main/java/com/baeldung/common/Utils.java
+++ b/src/main/java/com/baeldung/common/Utils.java
@@ -80,6 +80,7 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
@@ -446,14 +447,20 @@ public class Utils {
             compilationUnit.getResult()
                 .ifPresent(result -> result.findAll(ClassOrInterfaceDeclaration.class)
                     .forEach(c -> {
-                        addNewJavaConstructToTheList(GlobalConstants.CONSTRUCT_TYPE_CLASS_OR_INTERFACE, null, c.getNameAsString(), javaConstructs);
+                        // find out if the code sample is marked with @Generated
+                        final Optional<AnnotationExpr> hasGeneratedAnnotation = c.getAnnotations()
+                            .stream()
+                            .filter(annotationExpr -> annotationExpr.getNameAsString()
+                                .equalsIgnoreCase("Generated"))
+                            .findAny();
+                        addNewJavaConstructToTheList(GlobalConstants.CONSTRUCT_TYPE_CLASS_OR_INTERFACE, null, c.getNameAsString(), hasGeneratedAnnotation.isPresent(), javaConstructs);
                         c.getMethods()
-                            .forEach(m -> addNewJavaConstructToTheList(GlobalConstants.CONSTRUCT_TYPE_METHOD, c.getNameAsString(), m.getNameAsString(), javaConstructs));
+                            .forEach(m -> addNewJavaConstructToTheList(GlobalConstants.CONSTRUCT_TYPE_METHOD, c.getNameAsString(), m.getNameAsString(), false, javaConstructs));
                     }));
         }
     }
 
-    private static void addNewJavaConstructToTheList(String constructType, String constructParentTypeName, String constructName, List<JavaConstruct> javaConstructs) {
+    private static void addNewJavaConstructToTheList(String constructType, String constructParentTypeName, String constructName, boolean hasGeneratedAnnotation, List<JavaConstruct> javaConstructs) {
         for (JavaConstruct javaConstruct : javaConstructs) {
             if (constructType.equals(javaConstruct.getConstructType()) && constructName.equals(javaConstruct.getConstructName())) {
                 if (null == constructParentTypeName && null == javaConstruct.getConstructParentTypeName()) {
@@ -465,7 +472,7 @@ public class Utils {
                 return;
             }
         }
-        javaConstructs.add(new JavaConstruct(constructType, constructParentTypeName, constructName));
+        javaConstructs.add(new JavaConstruct(constructType, constructParentTypeName, constructName, hasGeneratedAnnotation));
     }
 
     private static void getJavaConstructsFromJavaCodeWrappingIntoDummyClass(String code, List<JavaConstruct> javaConstructs) {
@@ -480,9 +487,9 @@ public class Utils {
             compilationUnit.getResult()
                 .ifPresent(result -> result.findAll(ClassOrInterfaceDeclaration.class)
                     .forEach(c -> {
-                        addNewJavaConstructToTheList(GlobalConstants.CONSTRUCT_TYPE_CLASS_OR_INTERFACE, null, c.getNameAsString(), javaConstructs);
+                        addNewJavaConstructToTheList(GlobalConstants.CONSTRUCT_TYPE_CLASS_OR_INTERFACE, null, c.getNameAsString(), false, javaConstructs);
                         c.getMethods()
-                            .forEach(m -> addNewJavaConstructToTheList(GlobalConstants.CONSTRUCT_TYPE_METHOD, c.getNameAsString(), m.getNameAsString(), javaConstructs));
+                            .forEach(m -> addNewJavaConstructToTheList(GlobalConstants.CONSTRUCT_TYPE_METHOD, c.getNameAsString(), m.getNameAsString(), false, javaConstructs));
                     }));
         }
     }
@@ -519,11 +526,9 @@ public class Utils {
     }
 
     public static void filterAndCollectJavaConstructsNotFoundOnGitHub(List<JavaConstruct> javaConstructsOnPost, List<JavaConstruct> javaConstructsOnGitHub, Multimap<String, JavaConstruct> results, String url) {
-        javaConstructsOnPost.forEach(javaConstructOnPage -> {
-            if (javaConstructsOnGitHub.stream().filter(javaConstructOnGitHub -> javaConstructOnPage.equalsTo(javaConstructOnGitHub)).count() > 0) {
-                javaConstructOnPage.setFoundOnGitHub(true);
-            }
-        });
+        javaConstructsOnPost.forEach(javaConstructOnPage ->
+            javaConstructOnPage.setFoundOnGitHub(javaConstructsOnGitHub.stream().anyMatch(javaConstructOnPage::equalsTo))
+        );
 
         // @formatter:off
         javaConstructsOnPost.stream().filter(javaConstructOnPage -> !javaConstructOnPage.isFoundOnGitHub() && !javaConstructOnPage.getConstructName().equals(GlobalConstants.CONSTRUCT_DUMMY_CLASS_NAME))
@@ -532,7 +537,6 @@ public class Utils {
         if (!results.containsKey(url)) {
             results.put(url, null);
         }
-
     }
 
     public static String getErrorMessageForJavaConstructsTest(Multimap<String, JavaConstruct> results, String baseUrl) {

--- a/src/main/java/com/baeldung/common/vo/JavaConstruct.java
+++ b/src/main/java/com/baeldung/common/vo/JavaConstruct.java
@@ -3,26 +3,17 @@ package com.baeldung.common.vo;
 import com.baeldung.common.GlobalConstants;
 
 public class JavaConstruct {
-    private String constructType;
-    private String constructParentTypeName; // if constructType is Method, constructParentTypeName will contain the Java Class Type
-    private String constructName;
+    private final String constructType;
+    private final String constructParentTypeName; // if constructType is Method, constructParentTypeName will contain the Java Class Type
+    private final String constructName;
+    private final boolean hasGeneratedAnnotation;
     private boolean foundOnGitHub;
 
-    public JavaConstruct() {
-    }
-
-    public JavaConstruct(String constructType, String constructParentTypeName, String constructName, boolean foundOnGitHub) {
+    public JavaConstruct(String constructType, String constructParentTypeName, String constructName, boolean hasGeneratedAnnotation) {
         this.constructType = constructType;
         this.constructParentTypeName = constructParentTypeName;
         this.constructName = constructName;
-        this.foundOnGitHub = foundOnGitHub;
-    }
-
-    public JavaConstruct(String constructType, String constructParentTypeName, String constructName) {
-        super();
-        this.constructType = constructType;
-        this.constructParentTypeName = constructParentTypeName;
-        this.constructName = constructName;
+        this.hasGeneratedAnnotation = hasGeneratedAnnotation;
         this.foundOnGitHub = false;
     }
 
@@ -61,16 +52,8 @@ public class JavaConstruct {
         return constructType;
     }
 
-    public void setConstructType(String constructType) {
-        this.constructType = constructType;
-    }
-
     public String getConstructName() {
         return constructName;
-    }
-
-    public void setConstructName(String constructName) {
-        this.constructName = constructName;
     }
 
     public boolean isFoundOnGitHub() {
@@ -85,8 +68,7 @@ public class JavaConstruct {
         return constructParentTypeName;
     }
 
-    public void setConstructParentTypeName(String constructParentTypeName) {
-        this.constructParentTypeName = constructParentTypeName;
+    public boolean hasGeneratedAnnotation() {
+        return hasGeneratedAnnotation;
     }
-
 }

--- a/src/test/java/com/baeldung/jsoup/JavaConstructsTest.java
+++ b/src/test/java/com/baeldung/jsoup/JavaConstructsTest.java
@@ -82,7 +82,7 @@ public class JavaConstructsTest extends BaseJsoupTest {
                 }
                 postUrlsToGithubModuleLocalPaths.put(postUrl, modulePath);
             }
-            
+
         }
         logger.info("Finished - creating Map for Posts to Github Modules");
 
@@ -110,7 +110,10 @@ public class JavaConstructsTest extends BaseJsoupTest {
                 // get HTML of the post
                 Document jSoupDocument = Utils.getJSoupDocument(postUrl);
                 // get Java constructs from a post
-                List<JavaConstruct> javaConstructsOnPost = Utils.getJavaConstructsFromPreTagsInTheJSoupDocument(jSoupDocument);
+                final List<JavaConstruct> javaConstructsOnPost = Utils.getJavaConstructsFromPreTagsInTheJSoupDocument(jSoupDocument)
+                    .stream()
+                    .filter(javaConstruct -> !javaConstruct.hasGeneratedAnnotation()) // filter out @Generated classes
+                    .toList();
                 // collect Java constructs from the modules of post
                 final List<JavaConstruct> javaConstructsOnModules = modules.stream()
                     .flatMap(path -> moduleToJavaConstructs.get(path)


### PR DESCRIPTION
- extend JavaConstruct by detecting @Generated marked classes
- filter out @Generated code samples in the test code.